### PR TITLE
ci(github): Docker 이미지 빌드 및 푸시 GitHub Actions 워크플로 추가

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build & Push Backend Image
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Build JAR (with tests)
+        run: ./gradlew clean bootJar
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build & Push Docker Image
+        run: |
+          docker build -t <DOCKER_ID>/drive-backend:latest .
+          docker push <DOCKER_ID>/drive-backend:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,8 @@
-# syntax=docker/dockerfile:1.7
-
-############################
-# Build stage
-############################
-FROM gradle:8.10.2-jdk21 AS builder
-WORKDIR /workspace
-
-COPY build.gradle settings.gradle /workspace/
-COPY gradle /workspace/gradle
-RUN gradle --version > /dev/null
-
-COPY . /workspace
-
-RUN --mount=type=cache,target=/home/gradle/.gradle \
-    ./gradlew bootJar -x test --no-daemon && \
-    JAR_PATH=$(ls build/libs/*.jar | grep -v '\-plain.jar' | head -n 1) && \
-    mv "$JAR_PATH" build/libs/app.jar
-
-############################
-# Runtime stage
-############################
 FROM eclipse-temurin:21-jre
 ENV TZ=Asia/Seoul
 WORKDIR /app
 
-COPY --from=builder /workspace/build/libs/app.jar ./app.jar
+COPY build/libs/app.jar ./app.jar
 
 EXPOSE 8080
-
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     restart: unless-stopped
 
   app:
-    build: .
+    image: <DOCKER_ID>/drive-backend:latest   # ⭐ 핵심 변경
     container_name: drive-backend
     depends_on:
       db:


### PR DESCRIPTION
- main 브랜치 푸시에 빌드 및 푸시 동작하도록 GitHub Actions 구성
- Gradle 설정 및 JDK 21 세팅
- Docker Hub 로그인 및 이미지 빌드/푸시 단계 추가
- Docker Compose에 외부 빌드 이미지 참조로 변경
- Dockerfile에서 멀티스테이지 빌드 제거 및 단순화