### PR TITLE
fix: 로컬 Docker DUMMY OAuth 로그인 활성화

### DIFF
--- a/src/main/java/com/gumraze/rallyon/backend/auth/oauth/DummyOAuthClient.java
+++ b/src/main/java/com/gumraze/rallyon/backend/auth/oauth/DummyOAuthClient.java
@@ -1,11 +1,11 @@
 package com.gumraze.rallyon.backend.auth.oauth;
 
 import com.gumraze.rallyon.backend.auth.constants.AuthProvider;
-import org.springframework.context.annotation.Profile;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile({"local", "test"})
+@ConditionalOnProperty(prefix = "oauth.dummy", name = "enabled", havingValue = "true")
 public class DummyOAuthClient implements OAuthClient, ProviderAwareOAuthClient {
     @Override
     public AuthProvider supports() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,8 +20,9 @@ jwt:
     expiration-hours: ${JWT_REFRESH_TOKEN_EXPIRATION_HOURS}
 
 oauth:
-  allowed-providers:
-    - KAKAO
+  allowed-providers: ${OAUTH_ALLOWED_PROVIDERS:KAKAO}
+  dummy:
+    enabled: ${OAUTH_DUMMY_ENABLED:false}
   kakao:
     client-id: ${KAKAO_CLIENT_ID}
     client-secret: ${KAKAO_CLIENT_SECRET}


### PR DESCRIPTION
## 관련 이슈
- Closes #79

## 변경 요약
- DUMMY OAuth client를 프로필이 아닌 환경변수 기반으로 활성화되도록 변경
- oauth.allowed-providers를 환경변수 기반으로 제어하도록 정리
- 운영 기본값은 그대로 KAKAO만 허용하도록 유지

## 검증
- ./gradlew test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * OAuth 제공자 설정을 환경 변수 기반으로 변경했습니다.
  * 더미 OAuth 클라이언트 활성화 메커니즘을 환경 변수를 통해 제어하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->