### PR TITLE
fix: GHCR 이미지 네임스페이스를 정리한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
   packages: write
 
 env:
-  IMAGE_NAME: ghcr.io/drivebadminton/drive-backend
+  IMAGE_NAME: ghcr.io/rallyonprj/backend
 
 jobs:
   test:


### PR DESCRIPTION
## 변경 내용
- backend CI의 GHCR 이미지 경로를 `ghcr.io/rallyonprj/backend` 로 수정합니다.
- main push 시 immutable image publish가 실제 org namespace로 성공하도록 맞춥니다.

## 검증
- workflow YAML parse


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 컨테이너 이미지 저장소를 업데이트했습니다. CI/CD 워크플로우가 새로운 저장소에 Docker 이미지를 빌드하고 배포합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->