### PR TITLE
docs: 백엔드 작업 가이드 현행화

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,80 +1,137 @@
 # Backend Agent Guide
 
-This file defines the working rules for agents and contributors operating inside the RallyOn backend repository.
+This document defines the operating rules for agents and contributors working inside the RallyOn backend repository.
 
 ## Project Context
 
-- Stack: Java 21, Spring Boot 3.5, Spring Web, Spring Security, OAuth2 Client, JPA, Flyway, PostgreSQL, JWT, springdoc OpenAPI
+- Stack: Java 21, Spring Boot 4.0.2, Spring Web, Spring Security, OAuth2 Client, OAuth2 Resource Server, Authorization Server, JPA, Flyway, PostgreSQL, springdoc OpenAPI
 - Build tool: Gradle
 - Main package root: `com.gumraze.rallyon.backend`
-- Main verification command: `./gradlew test`
+- Default verification command: `./gradlew test`
+- Stronger packaging verification when runtime boundaries matter: `./gradlew clean test bootJar`
 
-## Architecture Expectations
+## Source-Of-Truth Documents
 
-The backend follows a package-by-domain structure with layered internals.
+Use each document for its intended concern:
 
-- `auth`, `user`, `region`, `courtManager`: domain-oriented packages
-- `controller`: web adapters and HTTP handling
-- `service`: use-case orchestration and business logic
-- `repository`: persistence access only
-- `entity`: JPA entities and persistence models
-- `dto`: request and response models
-- `api`: API contracts and interface-level definitions
-- `config`, `common`: cross-cutting configuration, exceptions, logging, security helpers
-- `web`: simple web-specific endpoints or redirects outside the main domain packages
+- [`ARCHITECTURE.md`](ARCHITECTURE.md): canonical architecture, module boundaries, ubiquitous language
+- [`TESTING.md`](TESTING.md): testing strategy, file placement, assertion style, TDD guidance
+- [`CONTRIBUTING.md`](CONTRIBUTING.md): issue, branch, commit, PR, and merge workflow
+- `AGENTS.md`: repository-local operating guidance for Codex and contributors
 
-Keep controllers thin, keep business decisions in services, and keep repositories focused on data access.
-Do not move domain logic into controllers, filters, or configuration classes.
+If this file appears to conflict with the code, verify the current package structure first and then update the document.
+
+## Current Architecture Shape
+
+The backend is not a pure layered codebase anymore.
+It is also not fully normalized into one uniform hexagonal package layout.
+Treat it as a modular monolith with mixed maturity by module.
+
+Current top-level modules include:
+
+- `identity`
+- `authorization`
+- `user`
+- `courtManager`
+- `region`
+- `api`
+- `common`
+- `config`
+- `security`
+- `web`
+
+### Complex Modules
+
+These modules mostly follow an `adapter / application / domain` shape:
+
+- `identity`
+- `authorization`
+- `user`
+- `courtManager`
+
+However, they are still in a transitional state.
+Some of them also retain supporting packages such as:
+
+- `dto`
+- `entity`
+- `constants`
+- `config`
+- `application/support`
+
+Do not assume every complex module has exactly the same package shape.
+Match the existing local structure of the module you touch.
+
+### Simpler Modules
+
+`region` is currently closer to a layered structure and uses packages such as:
+
+- `internal/web`
+- `internal/service`
+- `internal/persistence`
+- `dto`
+
+Do not force `region` into ports-and-adapters unless the architecture document and actual code both move that way.
+
+## Working Rules
+
+- Read the target module structure before introducing new packages.
+- Prefer fitting into the existing module shape over broad structural cleanup.
+- Do not mix a documentation task with repository-wide package refactoring.
+- Do not invent new shared abstractions unless the current change clearly needs them.
+- Keep security-sensitive logic explicit and easy to audit.
+- Keep transactional boundaries in application/service code, not in controllers or low-level adapters.
+
+## Module-Level Guidance
+
+- For `identity`, `authorization`, `user`, and `courtManager`, prefer use-case-oriented changes that respect the existing `adapter / application / domain` direction.
+- For these complex modules, do not introduce a second parallel architecture inside the same feature area.
+- For `region` and other simpler flows, keep the layered approach simple and avoid speculative ports/adapters.
+- `api`, `common`, `config`, `security`, and `web` are supporting boundaries. Do not move business rules there just because they are easier to reach.
 
 ## Engineering Principles
 
 ### TDD
 
-TDD is the default approach for business logic changes, bug fixes, and new behavior.
+TDD is the default for business logic changes, bug fixes, and new behavior.
 
 - Start from a failing test when the behavior is clear enough to specify.
 - Add regression coverage for bugs before or alongside the fix.
-- Keep the feedback loop short and prefer small `red -> green -> refactor` cycles.
-- Keep tests behavior-focused; avoid shallow framework-wiring tests unless wiring is the change.
-- Detailed testing conventions, stack roles, and examples live in [`TESTING.md`](TESTING.md).
+- Keep tests behavior-focused rather than framework-smoke focused.
+- Use [`TESTING.md`](TESTING.md) for concrete test layout and style.
 
 ### DRY
 
 - Remove real duplication, not incidental similarity.
-- Extract shared logic only after the duplication is stable and proven.
-- Prefer small local refactors over premature shared abstractions.
+- Extract shared logic only after the duplication is stable.
 
 ### KISS
 
 - Prefer straightforward Spring patterns over clever abstractions.
-- Favor explicit service methods, simple DTOs, and readable transaction boundaries.
-- Avoid framework-heavy indirection unless it clearly reduces complexity.
+- Keep use-case flow easy to follow from controller/adapter to application to domain.
 
 ### YAGNI
 
-- Do not introduce new layers, base classes, generic utilities, or extension points without an immediate use case.
-- Do not design for speculative future modules.
-- Keep configuration surface area as small as possible.
+- Do not introduce new layers, generic base classes, or speculative extension points without an immediate need.
+- Do not use a documentation update as an excuse to redesign package boundaries.
 
 ## Coding Rules
 
-- Prefer constructor injection. Do not introduce field injection.
-- Keep validation close to request boundaries and use explicit domain validation in services where needed.
-- Keep transactions intentional. Add them where business consistency requires them, not by default everywhere.
-- Prefer descriptive method names over comments that explain obvious behavior.
-- Preserve package boundaries. If a change spans multiple domains, make the use-case boundary explicit.
-- Keep security-sensitive code explicit and easy to audit.
+- Prefer constructor injection.
+- Keep request validation near the HTTP boundary and domain validation near the business rule.
+- Keep controller logic thin.
+- Keep persistence details out of domain code.
+- Prefer descriptive names over explanatory comments for simple behavior.
+- Use `record` freely for immutable request/response or command/result types when the local module already follows that direction.
 
-## Testing Rules
+## Verification Rules
 
-- TDD is the default.
 - Meaningful backend changes require `./gradlew test`.
-- Security, auth, and persistence changes require targeted tests.
-- Test style, file placement, fixtures, and helper extraction rules live in [`TESTING.md`](TESTING.md).
+- Runtime-boundary, packaging, or delivery-sensitive changes should additionally run `./gradlew clean test bootJar`.
+- Security, auth, persistence, and API contract changes require targeted tests, not only the full suite.
 
 ## Git Workflow
 
-Use this flow for backend work:
+Follow the repository workflow from [`CONTRIBUTING.md`](CONTRIBUTING.md):
 
 1. Create an issue.
 2. Create a branch from that issue.
@@ -82,45 +139,8 @@ Use this flow for backend work:
 4. Open a PR.
 5. Merge with squash merge.
 
-### Branch Naming
-
-- Format: `type/{issue-number}-{slug}`
-- Examples:
-  - `feat/123-login-page`
-  - `fix/87-cors`
-  - `refactor/201-auth-service-cleanup`
-
-Allowed `type` values:
-
-- `feat`
-- `fix`
-- `refactor`
-- `docs`
-- `chore`
-- `test`
-- `style`
-
-### Commit Convention
-
-Use Conventional Commits with an English type and a Korean subject line.
-
-- Format: `type: Korean summary`
-- Examples:
-  - `feat: 카카오 로그인 리다이렉트 수정`
-  - `fix: 사용자 프로필 조회 null 처리 보완`
-  - `refactor: JWT 검증 흐름 분리`
-
-PR titles must follow the same format because squash merge uses the PR title as the final commit title.
-
-## Change Scope Discipline
-
-- Keep each PR focused on one issue.
-- Do not mix unrelated refactors with functional changes.
-- If a repository-wide policy or documentation change affects developer workflow, it is usually better tracked as a separate backend issue.
-
 ## Practical Guidance For Agents
 
-- Read existing domain structure before introducing new packages.
-- Match the current architecture instead of inventing a new one mid-change.
-- Prefer updating existing tests and flows over adding parallel patterns.
-- If a requested change conflicts with TDD, DRY, KISS, or YAGNI, simplify the approach before implementing it.
+- Prefer facts from the current code over stale mental models.
+- If one module is in transition, keep your change locally consistent instead of normalizing the whole repository.
+- If a request would require repository-wide structural cleanup, separate that from the feature or bug-fix PR unless the issue explicitly asks for the refactor.


### PR DESCRIPTION
## Summary
- backend AGENTS.md를 현재 코드 구조와 문서 체계에 맞게 정리합니다
- 혼합 상태의 모듈 구조와 문서 역할 분리를 반영합니다
- 기본/보조 검증 명령을 실제 기준으로 맞춥니다

## Verification
- cd backend && ./gradlew test

Closes #110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서화**
  * 개발 저장소 운영 가이드 재구성 및 아키텍처 문서 개선
  * Spring Boot 기술 스택을 3.5에서 4.0.2로 업데이트
  * OAuth2 리소스 서버 및 인증 서버 보안 기능 확대
  * 검증 프로세스 및 모듈 구조 문서 최신화
  * Git 워크플로우 가이드라인 통합 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->